### PR TITLE
Support gradle 7 for react-native >= 0.68

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -36,5 +36,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Did a small change to be able to build Android with react-native >= 0.68

Related docs: https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal